### PR TITLE
2.4.1

### DIFF
--- a/chunking/__init__.py
+++ b/chunking/__init__.py
@@ -17,7 +17,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 
-__version__ = "2.4.0"
+__version__ = "2.4.1"
 
 version_split = __version__.split(".")
 __spec_version__ = (

--- a/chunking/base/validator.py
+++ b/chunking/base/validator.py
@@ -859,7 +859,7 @@ class BaseValidatorNeuron(BaseNeuron):
 
         except Exception as e:
             bt.logging.error(f"Error querying axon: {e}")
-            bt.logging.trace(traceback.format_exc())
+            # bt.logging.trace(traceback.format_exc())
 
             synapse.dendrite.status_code = 500
             synapse.dendrite.status_message = str(e)

--- a/chunking/base/validator.py
+++ b/chunking/base/validator.py
@@ -859,7 +859,7 @@ class BaseValidatorNeuron(BaseNeuron):
 
         except Exception as e:
             bt.logging.error(f"Error querying axon: {e}")
-            traceback.print_exc()
+            bt.logging.trace(traceback.format_exc())
 
             synapse.dendrite.status_code = 500
             synapse.dendrite.status_message = str(e)

--- a/chunking/base/validator.py
+++ b/chunking/base/validator.py
@@ -858,7 +858,7 @@ class BaseValidatorNeuron(BaseNeuron):
                 synapse.dendrite.process_time = str(time.time() - start_time)  # type: ignore
 
         except Exception as e:
-            bt.logging.error(f"Error querying axon: {e}")
+            # bt.logging.error(f"Error querying axon: {e}")
             # bt.logging.trace(traceback.format_exc())
 
             synapse.dendrite.status_code = 500

--- a/chunking/protocol.py
+++ b/chunking/protocol.py
@@ -51,6 +51,7 @@ class chunkSynapse(bt.Synapse):
     chunk_size: int
     chunk_qty: int
     time_soft_max: float
+    timeout: float = 20.0
 
     # Optional request input
     CID: Optional[str] = None

--- a/chunking/utils/config.py
+++ b/chunking/utils/config.py
@@ -231,14 +231,14 @@ def add_args(cls, parser):
             "--doc_gen.concurrent_n",
             type=int,
             help="The number of concurrent document generation tasks to run.",
-            default=5,
+            default=6,
         )
 
         parser.add_argument(
-            "--doc_gen.interval_seconds",
-            type=int,
-            help="The interval between document generation tasks in seconds.",
-            default=0,
+            "--doc_gen.timeout",
+            type=float,
+            help="Time to weight before timing out a synthetic doc generation task",
+            default=160,
         )
 
         parser.add_argument(
@@ -326,7 +326,7 @@ def add_args(cls, parser):
             help="The minimum number of seconds to wait before reconnecting to the network.",
             default=2,
         )
-        
+
         parser.add_argument(
             "--neuron.reconnect.max_seconds",
             type=int,

--- a/chunking/utils/config.py
+++ b/chunking/utils/config.py
@@ -96,13 +96,6 @@ def add_args(cls, parser):
         )
 
         parser.add_argument(
-            "--wandb.project_name",
-            type=str,
-            help="The name of the wandb project.",
-            default=chunking.PROJECT_NAME,
-        )
-
-        parser.add_argument(
             "--neuron.sample_size",
             type=int,
             help="The number of miners to query in a single step.",
@@ -161,9 +154,23 @@ def add_args(cls, parser):
         )
 
         parser.add_argument(
+            "--wandb.project_name",
+            type=str,
+            help="The name of the wandb project.",
+            default=chunking.PROJECT_NAME,
+        )
+
+        parser.add_argument(
             "--wandb.wandb_off",
             action="store_true",
             help="Turn off wandb logging.",
+        )
+
+        parser.add_argument(
+            "--wandb.log_stdout_if_off",
+            action="store_true",
+            help="If set, logs to stdout if wandb is off.",
+            default=False,
         )
 
         parser.add_argument(
@@ -232,6 +239,20 @@ def add_args(cls, parser):
             type=int,
             help="The interval between document generation tasks in seconds.",
             default=0,
+        )
+
+        parser.add_argument(
+            "--no_forward",
+            action="store_true",
+            help="If set, does not forward queries to miners. Useful for debugging.",
+            default=False,
+        )
+
+        parser.add_argument(
+            "--query_axons_type",
+            type=str,
+            help="The type of query axons to use.",
+            default="custom",
         )
 
     # Miner

--- a/chunking/utils/integrated_api/chunk/chunk.py
+++ b/chunking/utils/integrated_api/chunk/chunk.py
@@ -32,14 +32,16 @@ async def chunk_handler(self, request: ChunkRequest) -> ChunkResponse:
         request.document, request.chunk_size
     )
 
-    bt.logging.info(f"chunk qty: {chunk_qty}")
-
     input_synapse = chunkSynapse(
         document=request.document,
         chunk_size=request.chunk_size,
         chunk_qty=chunk_qty,
-        timeout=request.timeout,
         time_soft_max=request.timeout * request.time_soft_max_multiplier,
+        timeout=request.timeout,
+    )
+
+    bt.logging.debug(
+        f"input - timeout: {input_synapse.timeout} | chunk_size: {input_synapse.chunk_size} | chunk_qty: {input_synapse.chunk_qty} | time_soft_max: {input_synapse.time_soft_max}"
     )
 
     if request.do_scoring:

--- a/chunking/utils/synthetic/synthetic.py
+++ b/chunking/utils/synthetic/synthetic.py
@@ -271,6 +271,7 @@ async def generate_doc_normal(validator, pageid=None) -> Tuple[str, int]:
 gen_types: List[SyntheticGenType] = ["old", "new"]
 probabilities_gen_types = [0.2, 0.8]
 
+
 async def generate_document(validator) -> Tuple[str, int]:
     """
     Generate a synthetic document for a synthetic tournament round. Either from wikipedia or with an llm.
@@ -287,9 +288,7 @@ async def generate_document(validator) -> Tuple[str, int]:
         return await generate_doc_normal(validator)
     else:
         gen_type = np.random.choice(gen_types, p=probabilities_gen_types)
-        bt.logging.info(
-            f"Generating synthetic document with llm, gen_type: {gen_type}"
-        )
+        bt.logging.info(f"Generating synthetic document with llm, gen_type: {gen_type}")
         synthetic_document, article_names = await generate_doc_with_llm(
             validator, gen_type=gen_type
         )

--- a/chunking/utils/wandb/wandb.py
+++ b/chunking/utils/wandb/wandb.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta
 import os
 import time
+import traceback
 import chunking
 import wandb
 from wandb.apis.public.runs import Runs, Run
@@ -67,7 +68,8 @@ class WandbLogger:
         if not self.is_off():
             wandb.log(*args, **kwargs)
         else:
-            bt.logging.info(f"Wandb is off, not logging {args} {kwargs}")
+            if self.validator.config.wandb.log_stdout_if_off:
+                bt.logging.info(f"Wandb is off, logging to stdout: {args} {kwargs}")
 
     def restart_if_past_time_delta(self, time_delta: timedelta):
         # query = gql(QUERY_TEMPLATE % RUN_FRAGMENT)
@@ -289,4 +291,4 @@ class WandbLogger:
                 return run
 
             except Exception as e:
-                raise Exception(f"Error in init_wandb: {e}")
+                raise Exception(f"Error in init_wandb: {e}. {traceback.format_exc()}")

--- a/chunking/validator/__init__.py
+++ b/chunking/validator/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.4.0"
+__version__ = "2.4.1"
 
 version_split = __version__.split(".")
 __spec_version__ = (

--- a/chunking/validator/reward.py
+++ b/chunking/validator/reward.py
@@ -446,9 +446,7 @@ async def get_rewards(
     for response in responses:
         miner_hotkey = response.axon.hotkey or "not found"
         print(f"handling response from {miner_hotkey[:10]}")
-        chunks_hash = (
-            get_chunks_hash(response.chunks) if response is not None else ""
-        )
+        chunks_hash = get_chunks_hash(response.chunks) if response is not None else ""
         if chunks_hash not in hashes and response is not None:
 
             async def _calculate_reward():

--- a/chunking/validator/tournament.py
+++ b/chunking/validator/tournament.py
@@ -22,7 +22,9 @@ from chunking.validator.types import EndTournamentRoundInfo
 from chunking.protocol import chunkSynapse
 
 
-def create_groups(rankings: np.ndarray, group_size: int) -> tuple[list[np.ndarray[int]], list[range], list[np.ndarray[float]]]:
+def create_groups(
+    rankings: np.ndarray, group_size: int
+) -> tuple[list[np.ndarray[int]], list[range], list[np.ndarray[float]]]:
     """
     Creates groups of miners based on the rankings. The group size increases as the ranks get worse (higher number).
     There is always overlap between each group, with the size of the overlap being group_size // 2.
@@ -181,7 +183,7 @@ async def query_miner_group(
     miner_group_index: int | None = None,
 ) -> list[chunkSynapse]:
     bt.logging.debug(
-        f"Querying miner group ({miner_group_index}): {miner_group_uids}, timeout: {input_synapse.timeout}"
+        f"Querying miner group ({miner_group_index}): {miner_group_uids}, timeout: {input_synapse.timeout}, chunk_size: {input_synapse.chunk_size}, chunk_qty: {input_synapse.chunk_qty}, document length: {len(input_synapse.document)}. Document snippet: {input_synapse.document[:100]}..."
     )
     axons: list[bt.axon] = [self.metagraph.axons[uid] for uid in miner_group_uids]
 
@@ -271,6 +273,7 @@ async def score_miner_group_responses(
         input_synapse = task.synapse
 
         bt.logging.debug("calling get_rewards() async")
+        bt.logging.debug(f"len(responses): {len(responses)}")
         rewards, extra_infos = await get_rewards(
             document=input_synapse.document,
             chunk_size=input_synapse.chunk_size,
@@ -345,7 +348,7 @@ async def score_miner_group_responses(
             do_wandb_log=do_wandb_log,
             wandb_data=wandb_data,
             task_type=task.task_type,
-            group_best_possible_rank_value=group_rank_values[0] or -1
+            group_best_possible_rank_value=group_rank_values[0] or -1,
         )
 
         # bt.logging.debug(f"End tournament round info: {end_tournament_round_info}")

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -17,6 +17,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 
+import random
 import time
 import traceback
 from typing import Dict, List, Tuple
@@ -332,7 +333,12 @@ class Miner(BaseMinerNeuron):
 
         # default miner logic, see docs/miner_guide.md for help writing your own miner logic
         bt.logging.debug(
-            f"from hotkey {synapse.dendrite.hotkey[:10]}: Received chunk_size: {synapse.chunk_size}, time_soft_max: {synapse.time_soft_max}"
+            "\n"
+            + "-" * 100
+            + "\n"
+            + f"from hotkey {synapse.dendrite.hotkey[:10]}: Received chunk_size: {synapse.chunk_size}, time_soft_max: {synapse.time_soft_max}, timeout: {synapse.timeout}. Document length: {len(synapse.document)}. Doc snippet: {synapse.document[:100]}..."
+            + "\n"
+            + "-" * 100
         )
 
         if not self.config.neuron.no_check_ipfs:
@@ -371,7 +377,7 @@ class Miner(BaseMinerNeuron):
         data_to_sign = str.encode(json.dumps(response_data))
         bt.logging.trace(f"data to sign: {data_to_sign[:100]}...")
         signature = self.wallet.get_hotkey().sign(data_to_sign)
-        
+
         return signature.hex()
 
     async def blacklist(

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -1,0 +1,103 @@
+import argparse
+import asyncio
+import random
+import time
+from chunking.utils.integrated_api.chunk.types import ChunkResponse
+from tests.test_integrated_api import get_doc_and_query
+from tests.utils.articles import get_articles
+
+
+async def main(args: argparse.Namespace | None = None):
+    print("Getting test pageids")
+    test_pageids = get_articles()
+
+    print(f"Got {len(test_pageids)} test pageids")
+
+    if args is None:
+        num_articles = 5
+        batch_size = 1
+        group_indices = None
+        custom_uids = [16, 17, 18]
+        timeout = 20
+        sleep_time = 0.0
+    else:
+        num_articles = args.num_articles
+        batch_size = args.batch_size
+        group_indices = args.group_indices
+        custom_uids = args.custom_uids
+        timeout = args.timeout
+        sleep_time = args.sleep_time
+
+    if not group_indices and not custom_uids:
+        print("Must provide either group indices or custom uids")
+        exit(1)
+
+    if group_indices and custom_uids:
+        print("Cannot provide both group indices and custom uids")
+        exit(1)
+
+    for i in range(0, num_articles, batch_size):
+        batch_pageids = test_pageids[i : i + batch_size]
+
+        coros = [
+            get_doc_and_query(
+                pageid,
+                random.choice(group_indices) if group_indices is not None else None,
+                custom_miner_uids=custom_uids,
+                timeout=timeout,
+            )
+            for pageid in batch_pageids
+        ]
+
+        responses = await asyncio.gather(*coros)
+
+        for j, response in enumerate(responses):
+            chunk_response = ChunkResponse.model_validate(response.json())
+
+            is_error = False
+
+            uids_seen = set()
+
+            for result in chunk_response.results:
+                uids_seen.add(result.uid)
+
+                if result.chunks is None:
+                    print(
+                        f"Got None chunks for pageid {batch_pageids[j]}, uid: {result.uid} in group {result.miner_group_index}. Process time: {result.process_time}"
+                    )
+                    is_error = True
+                else:
+                    print(
+                        f"Got {len(result.chunks)} chunks for pageid {batch_pageids[j]}, uid: {result.uid} in group {result.miner_group_index}. Process time: {result.process_time}"
+                    )
+
+            if custom_uids is not None:
+                if len(uids_seen) != len(custom_uids):
+                    print(f"Missing uids: {set(custom_uids) - uids_seen}")
+                    raise ValueError(f"Missing uids: {set(custom_uids) - uids_seen}")
+
+            if is_error:
+                raise ValueError("Error(s) found in responses")
+
+        time.sleep(sleep_time)
+
+
+def test_queries():
+    asyncio.run(main())
+
+
+if __name__ == "__main__":
+    argparser = argparse.ArgumentParser()
+    argparser.add_argument("--num_articles", "-n", type=int, default=5)
+    argparser.add_argument("--batch_size", "-b", type=int, default=1)
+    argparser.add_argument("--sleep_time", "-s", type=float, default=0.0)
+    argparser.add_argument("--group_indices", "-g", type=int, nargs="+", default=None)
+    argparser.add_argument("--custom_uids", "-c", type=int, nargs="+", default=None)
+    argparser.add_argument("--timeout", "-t", type=float, default=20)
+    argparser.add_argument(
+        "--time_soft_max_multiplier", "-tm", type=float, default=0.75
+    )
+
+    args = argparser.parse_args()
+
+    main(args)

--- a/tests/utils/integrated_api.py
+++ b/tests/utils/integrated_api.py
@@ -1,0 +1,88 @@
+import logging
+import time
+import httpx
+from chunking.utils.integrated_api.chunk.types import ChunkRequestType
+from chunking.utils.synthetic.synthetic import get_wiki_content_for_page
+
+
+BASE_URL = "http://localhost:8080"
+logger = logging.getLogger(__name__)
+
+
+async def query_integrated_api(
+    miner_group_index: int | None,
+    document: str,
+    do_wandb_log: bool,
+    do_scoring: bool,
+    chunk_size: int,
+    custom_miner_uids: list[int] | None,
+    type: ChunkRequestType,
+    benchmark_id: str | None = None,
+):
+    if not miner_group_index and not custom_miner_uids:
+        raise ValueError(
+            "Either miner_group_index or custom_miner_uids must be provided"
+        )
+
+    async with httpx.AsyncClient() as client:
+        req_body = {
+            "chunk_size": chunk_size,
+            "document": document,
+            "do_wandb_log": do_wandb_log,
+            "do_scoring": do_scoring,
+            "request_type": type.value,
+            "benchmark_id": benchmark_id,
+        }
+
+        if miner_group_index is not None:
+            req_body["miner_group_index"] = miner_group_index
+
+        if custom_miner_uids is not None:
+            req_body["custom_miner_uids"] = custom_miner_uids
+
+        response = await client.post(
+            f"{BASE_URL}/chunk",
+            json=req_body,
+            timeout=None,
+        )
+
+        return response
+
+
+async def get_doc_and_query(
+    pageid: int,
+    miner_group_index: int | None = None,
+    chunk_size: int = 4096,
+    do_wandb_log: bool = True,
+    do_scoring: bool = True,
+    custom_miner_uids: list[int] | None = None,
+    type: ChunkRequestType = ChunkRequestType.normal,
+    benchmark_id: str | None = None,
+):
+    logger.info(f"Getting document for pageid {pageid}")
+    content, title = await get_wiki_content_for_page(pageid)
+
+    logger.info(f"Got document {title} of len {len(content)}")
+
+    start_time = time.time()
+
+    res = await query_integrated_api(
+        miner_group_index=miner_group_index,
+        document=content,
+        do_wandb_log=do_wandb_log,
+        do_scoring=do_scoring,
+        chunk_size=chunk_size,
+        custom_miner_uids=custom_miner_uids,
+        type=type,
+        benchmark_id=benchmark_id,
+    )
+
+    end_time = time.time()
+
+    res_time = end_time - start_time
+
+    logger.info(
+        f"Got response for group {miner_group_index}, pageid {pageid} of doc of len {len(content)} in {res_time} seconds"
+    )
+
+    return res


### PR DESCRIPTION
# Changelog
- [x] custom axon querying function (function that sends query to miner). Took logic from `bittensor` package and switched out `aiohttp` for `httpx` as the http client due to noticing some strange behavior with the former on both mainnet and localnet.
- [x] Continous synthetic document generation. Instead of generating a batch of _k_ documents, waiting for all of them to complete and starting a new batch, it now will generate a max of _k_ at a time and then start a new synthetic document generation task as soon as a previous one completes, increasing concurrency

# Checklist
- [x] tests pass
- [x] test autoupdate
- [x] version bump