### PR TITLE
Fix line links in evaluation doc

### DIFF
--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -12,19 +12,19 @@ In the default validator, [reward.py](../chunking/validator/reward.py) rewards t
 
 First, the validator confirms that each word in the chunked response also exists, in the same order, in the original document.
 
-https://github.com/VectorChat/chunking_subnet/blob/8c00fd799bfa4d53b2bcaeb1718f76bcfbacfe5d/chunking/validator/reward.py#L56-L123
+https://github.com/VectorChat/chunking_subnet/blob/8ac69eb9d9690678ff0ec30f1b07eb185f34e07a/chunking/validator/reward.py#L56-L123
 
 ### 2. Check that all document words can be found in at least one chunk
 
 Then, the validator confirms that every set of 3 adjacent words in the original document is also present within the chunked response.
 
-https://github.com/VectorChat/chunking_subnet/blob/8c00fd799bfa4d53b2bcaeb1718f76bcfbacfe5d/chunking/validator/reward.py#L126-L147
+https://github.com/VectorChat/chunking_subnet/blob/8ac69eb9d9690678ff0ec30f1b07eb185f34e07a/chunking/validator/reward.py#L126-L147
 
 ### 3. Check that each chunk ends on a sentence boundary
 
 Finally, the validator checks that each chunk ends on a sentence boundary.
 
-https://github.com/VectorChat/chunking_subnet/blob/8c00fd799bfa4d53b2bcaeb1718f76bcfbacfe5d/chunking/validator/reward.py#L151-L159
+https://github.com/VectorChat/chunking_subnet/blob/8ac69eb9d9690678ff0ec30f1b07eb185f34e07a/chunking/validator/reward.py#L151-L159
 
 If any of these checks fail, the miner is rewarded 0 for the chunk submitted in that tournament round.
 
@@ -32,15 +32,15 @@ If any of these checks fail, the miner is rewarded 0 for the chunk submitted in 
 
 After passing the fail states, the validator parses through each chunk, creating 'small chunks' of 3 sentences or fewer.
 
-https://github.com/VectorChat/chunking_subnet/blob/8c00fd799bfa4d53b2bcaeb1718f76bcfbacfe5d/chunking/validator/reward.py#L281-L285
+https://github.com/VectorChat/chunking_subnet/blob/8ac69eb9d9690678ff0ec30f1b07eb185f34e07a/chunking/validator/reward.py#L281-L285
 
 A random sample, of `num_embeddings` size, is taken and then embedded. The default value is 150.
 
-https://github.com/VectorChat/chunking_subnet/blob/8c00fd799bfa4d53b2bcaeb1718f76bcfbacfe5d/chunking/validator/reward.py#L301-L305
+https://github.com/VectorChat/chunking_subnet/blob/8ac69eb9d9690678ff0ec30f1b07eb185f34e07a/chunking/validator/reward.py#L301-L305
 
 Then, to calculate the similarity score, the dot product of every possible pair of embeddings is calculated. The average of each pair originating from the same chunk is added to the score (intrachunk similarity), while the average of each pair originating from different chunks is subtracted from the score (interchunk dissimilarity).
 
-https://github.com/VectorChat/chunking_subnet/blob/8c00fd799bfa4d53b2bcaeb1718f76bcfbacfe5d/chunking/validator/reward.py#L331-L351
+https://github.com/VectorChat/chunking_subnet/blob/8ac69eb9d9690678ff0ec30f1b07eb185f34e07a/chunking/validator/reward.py#L331-L351
 
 Here is a visualization of how the validator calculates a miner’s score:
 
@@ -53,7 +53,7 @@ Finally, penalities are deducted from the reward exponentially.
 Responses are penalized exponentially for each character over the maximum chunk length `chunk_size` and for each chunk over the maximum chunk quantity `chunk_qty`.
 Validators exponentially penalize responses for each second they are late.
 
-https://github.com/VectorChat/chunking_subnet/blob/8c00fd799bfa4d53b2bcaeb1718f76bcfbacfe5d/chunking/validator/reward.py#L363-L390
+https://github.com/VectorChat/chunking_subnet/blob/8ac69eb9d9690678ff0ec30f1b07eb185f34e07a/chunking/validator/reward.py#L363-L390
 
 The penalties are summed and applied to the reward with the following formula:
 


### PR DESCRIPTION
Was linking to the wrong blob, so all the snippets were off.
This changes the link to the current main HEAD commit